### PR TITLE
Refactor for extensibility; convert GoodreadsProcessor to generic tagger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ msbuild.wrn
 
 # Database
 wallabag_reducer.sqlite3
+
+# Config
+config.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Unreleased
+
+- Removed `DATABASE_FILE` env var
+- Added `DATA_DIR` env var to set database & config directory
+- Added processor configuration file (`$DATA_DIR/config.json`)
+- Converted `GoodreadsProcessor` to generic website to tag mapper
+- Refactored core to enable further extensibility

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ COPY . ./
 RUN dotnet ef database update
 RUN dotnet publish -c Release -o out
 
+ENV DATA_DIR=/config
+
 FROM microsoft/dotnet:2.2-runtime AS runtime
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/GenericTagProcessor.cs
+++ b/GenericTagProcessor.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json.Linq;
+using wallabag.Api;
+using wallabag.Api.Models;
+
+namespace WallabagReducer.Net
+{
+    class GenericTagProcessor : IProcessor
+    {
+        private readonly IList<Mapping> mappings;
+
+        public bool should_run { get; set; } = true;
+
+        class Mapping
+        {
+            public string domain { get; set; }
+            public string tag { get; set; }
+        }
+
+        public GenericTagProcessor(JObject config)
+        {
+            mappings = config["GenericTagProcessor"]?["tag_mapping"]?.ToObject<IList<Mapping>>();
+            should_run = mappings != null;
+        }
+
+        public async Task Process(WallabagClient client, WallabagItem item)
+        {
+            foreach (var mapping in mappings)
+            {
+                // Not a matching entry
+                if (!item.Url.Contains(mapping.domain))
+                    continue;
+                // Already tagged
+                if (item.Tags.Any(t => t.Label == mapping.tag))
+                    continue;
+                Console.Write(item.Title.Replace("\n", " "));
+                await client.AddTagsAsync(item, new[] { mapping.tag });
+                Console.WriteLine($" {mapping.tag} ✓");
+            }
+        }
+    }
+}

--- a/HNProcessor.cs
+++ b/HNProcessor.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json.Linq;
+using wallabag.Api;
+using wallabag.Api.Models;
+
+namespace WallabagReducer.Net
+{
+    class HNProcessor : IProcessor
+    {
+        Regex _regex;
+        Regex regex()
+        {
+            if (_regex == null)
+            {
+                _regex = new Regex("<a href=\"([a-z]{2,6}://[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b[-a-zA-Z0-9@:%_\\+.~#?&//=]*)\"[^>]*class=\"storylink\">",
+                                    RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            }
+            return _regex;
+        }
+
+        public bool should_run { get; set; } = false;
+
+        async Task<HNArticle> Extract_HN_article(WallabagClient client, WallabagItem item)
+        {
+            // Not a HN article
+            if (!item.Url.Contains("news.ycombinator"))
+                return null;
+            // Not scraped correctly?
+            if (item.Content == null)
+                return null;
+
+            // Search for HN storylink
+            var matches = regex().Matches(item.Content);
+            // Ignore no match posts (Ask HN, etc)
+            if (matches.Count == 0 || matches[0].Groups.Count <= 1)
+                return null;
+            var content_url = matches[0].Groups[1].Value;
+            // Ignore self HN posts
+            if (content_url.Contains("news.ycombinator"))
+                return null;
+
+            Console.Write($"Adding {content_url}");
+            WallabagItem newItem = await client.AddAsync(
+                new Uri(content_url),
+                tags: new string[] { "hacker-news" }
+            );
+            Console.WriteLine(" ✓");
+            if (newItem.Url != content_url)
+            {
+                Console.WriteLine($"URLs don't match: {content_url} {newItem.Url}");
+            }
+
+            return new HNArticle
+            {
+                SourceWBId = item.Id,
+                SourceUrl = item.Url,
+                ContentWBId = newItem.Id,
+                ContentUrl = content_url
+            };
+        }
+
+        public async Task Process(WallabagClient client, WallabagItem item)
+        {
+            using (var db = new WallabagContext())
+            {
+                // Filter out HN articles that have already been processed
+                var exists = db.ProcessedHNArticles.Any(a => a.SourceWBId == item.Id || a.ContentWBId == item.Id);
+                if (!exists)
+                {
+                    var hn = await Extract_HN_article(client, item);
+                    if (hn != null)
+                    {
+                        db.ProcessedHNArticles.Add(hn);
+                        var count = await db.SaveChangesAsync();
+                        Console.WriteLine("{0} HN records saved to database", count);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,90 +1,26 @@
 ﻿using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
-using System.Text.RegularExpressions;
 
+using Microsoft.EntityFrameworkCore;
 using MoreLinq;
+using Newtonsoft.Json.Linq;
 using wallabag.Api;
 using wallabag.Api.Models;
-using Microsoft.EntityFrameworkCore;
 
 namespace WallabagReducer.Net
 {
-    class HNProcessor
+    interface IProcessor
     {
-        Regex _regex;
-        Regex regex()
-        {
-            if (_regex == null)
-            {
-                _regex = new Regex("<a href=\"([a-z]{2,6}://[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b[-a-zA-Z0-9@:%_\\+.~#?&//=]*)\"[^>]*class=\"storylink\">",
-                                    RegexOptions.Compiled | RegexOptions.IgnoreCase);
-            }
-            return _regex;
-        }
+        bool should_run { get; }
 
-        public async Task<HNArticle> Extract_HN_article(WallabagClient client, WallabagItem item)
-        {
-            // Not a HN article
-            if (!item.Url.Contains("news.ycombinator"))
-                return null;
-            // Not scraped correctly?
-            if (item.Content == null)
-                return null;
-
-            // Search for HN storylink
-            var matches = regex().Matches(item.Content);
-            // Ignore no match posts (Ask HN, etc)
-            if (matches.Count == 0 || matches[0].Groups.Count <= 1)
-                return null;
-            var content_url = matches[0].Groups[1].Value;
-            // Ignore self HN posts
-            if (content_url.Contains("news.ycombinator"))
-                return null;
-
-            Console.Write($"Adding {content_url}");
-            WallabagItem newItem = await client.AddAsync(
-                new Uri(content_url),
-                tags: new string[] { "hacker-news" }
-            );
-            Console.WriteLine(" ✓");
-            if (newItem.Url != content_url)
-            {
-                Console.WriteLine($"URLs don't match: {content_url} {newItem.Url}");
-            }
-
-            return new HNArticle
-            {
-                SourceWBId = item.Id,
-                SourceUrl = item.Url,
-                ContentWBId = newItem.Id,
-                ContentUrl = content_url
-            };
-        }
-    }
-
-    class GoodreadsProcessor
-    {
-        public async Task Tag_Goodreads_article(WallabagClient client, WallabagItem item)
-        {
-            // Not a goodreads entry
-            if (!item.Url.Contains("goodreads.com"))
-                return;
-            // Already tagged
-            if (item.Tags.Any(t => t.Label == "goodreads"))
-                return;
-            Console.Write(item.Title);
-            await client.AddTagsAsync(item, new[] { "goodreads" });
-            Console.WriteLine(" ✓");
-        }
+        Task Process(WallabagClient client, WallabagItem item);
     }
 
     class Program
     {
-        static HNProcessor hnx = new HNProcessor();
-        static GoodreadsProcessor grx = new GoodreadsProcessor();
-
         static async Task<List<WallabagItem>> GetAllEntries(WallabagClient client)
         {
             List<WallabagItem> list = new List<WallabagItem>();
@@ -104,33 +40,23 @@ namespace WallabagReducer.Net
             return list;
         }
 
-        static async Task runOne(WallabagContext db, WallabagClient client, WallabagItem item)
+        static async Task runOne(WallabagClient client, IEnumerable<IProcessor> processors, WallabagItem item)
         {
-            // Filter out HN articles that have already been processed
-            var exists = db.ProcessedHNArticles.Any(a => a.SourceWBId == item.Id || a.ContentWBId == item.Id);
-            if (!exists)
+            foreach (var processor in processors)
             {
-                var hn = await hnx.Extract_HN_article(client, item);
-                if (hn != null)
-                {
-                    db.ProcessedHNArticles.Add(hn);
-                    var count = await db.SaveChangesAsync();
-                    Console.WriteLine("{0} HN records saved to database", count);
-                }
+                await processor.Process(client, item);
             }
-
-            await grx.Tag_Goodreads_article(client, item);
         }
 
-        static async Task run(WallabagClient client, int poll_duration)
+        static async Task run(WallabagClient client, IEnumerable<IProcessor> processors, int poll_duration)
         {
+            var valid_processors = processors.Where(proc => proc.should_run);
+
             // Run all existing items
             var list = await GetAllEntries(client);
-            list.ForEach(async item => {
-                using (var db = new WallabagContext())
-                {
-                    await runOne(db, client, item);
-                }
+            list.ForEach(async item =>
+            {
+                await runOne(client, valid_processors, item);
             });
 
             // Get max Wallabag ID from list
@@ -146,25 +72,81 @@ namespace WallabagReducer.Net
                     await Task.Delay(poll_duration);
                     continue;
                 }
-                using (var db = new WallabagContext())
-                {
-                    await runOne(db, client, item);
-                }
+                await runOne(client, valid_processors, item);
                 maxWBId++;
                 Console.WriteLine($"Next Wallabag ID: {maxWBId}");
             }
         }
 
-        static void Main(string[] args)
+        class AppConfig
         {
-            var wallabag_url = Environment.GetEnvironmentVariable("WALLABAG_URL");
-            var wallabag_client_id = Environment.GetEnvironmentVariable("WALLABAG_CLIENT_ID");
-            var wallabag_client_secret = Environment.GetEnvironmentVariable("WALLABAG_CLIENT_SECRET");
-            var wallabag_username = Environment.GetEnvironmentVariable("WALLABAG_USERNAME");
-            var wallabag_password = Environment.GetEnvironmentVariable("WALLABAG_PASSWORD");
-            var wallabag_poll_duration = int.Parse(Environment.GetEnvironmentVariable("WALLABAG_POLL_DURATION_SECONDS")) * 1000;
-            var database_file = Environment.GetEnvironmentVariable("DATABASE_FILE") ?? "wallabag_reducer.sqlite3";
-            WallabagContext.database_file = database_file;
+            public string url { get; set; }
+            public string client_id { get; set; }
+            public string client_secret { get; set; }
+            public string username { get; set; }
+            public string password { get; set; }
+            public int poll_duration { get; set; }
+            public string data_dir { get; set; }
+            public string database_file { get; set; }
+            public string config_file { get; set; }
+
+            public bool Validate()
+            {
+                if(!string.IsNullOrWhiteSpace(url)) {
+                    throw new Exception("WALLABAG_URL not set");
+                }
+                if(!string.IsNullOrWhiteSpace(client_id)) {
+                    throw new Exception("WALLABAG_CLIENT_ID not set");
+                }
+                if(!string.IsNullOrWhiteSpace(client_secret)) {
+                    throw new Exception("WALLABAG_CLIENT_SECRET not set");
+                }
+                if(!string.IsNullOrWhiteSpace(username)) {
+                    throw new Exception("WALLABAG_USERNAME not set");
+                }
+                if(!string.IsNullOrWhiteSpace(password)) {
+                    throw new Exception("WALLABAG_PASSWORD not set");
+                }
+                return true;
+            }
+        }
+
+        static int Main(string[] args)
+        {
+            var appConfig = new AppConfig
+            {
+                url = Environment.GetEnvironmentVariable("WALLABAG_URL"),
+                client_id = Environment.GetEnvironmentVariable("WALLABAG_CLIENT_ID"),
+                client_secret = Environment.GetEnvironmentVariable("WALLABAG_CLIENT_SECRET"),
+                username = Environment.GetEnvironmentVariable("WALLABAG_USERNAME"),
+                password = Environment.GetEnvironmentVariable("WALLABAG_PASSWORD"),
+                poll_duration = int.Parse(Environment.GetEnvironmentVariable("WALLABAG_POLL_DURATION_SECONDS") ?? "60") * 1000,
+                data_dir = Environment.GetEnvironmentVariable("DATA_DIR") ?? "",
+                database_file = "wallabag_reducer.sqlite3",
+                config_file = "config.json"
+            };
+
+            WallabagContext.database_file = Path.Combine(appConfig.data_dir, appConfig.database_file);
+
+            var config_path = Path.Combine(appConfig.data_dir, appConfig.config_file);
+            if (!File.Exists(config_path))
+            {
+                Console.WriteLine($"No config file, exiting (expected at {config_path}");
+                return -1;
+            }
+
+            try
+            {
+                appConfig.Validate();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Invalid environment configuration: {e.Message}");
+                return -1;
+            }
+
+            // Load processor config file
+            var processorConfig = JObject.Parse(File.ReadAllText(config_path));
 
             // Create DB & run any necessary migrations
             using (var db = new WallabagContext())
@@ -172,12 +154,20 @@ namespace WallabagReducer.Net
                 db.Database.Migrate();
             }
 
-            WallabagClient client = new WallabagClient(new System.Uri(wallabag_url), wallabag_client_id, wallabag_client_secret);
-            var tok = client.RequestTokenAsync(wallabag_username, wallabag_password);
+            // Create & auth with Wallabag instance
+            WallabagClient client = new WallabagClient(new System.Uri(appConfig.url), appConfig.client_id, appConfig.client_secret);
+            var tok = client.RequestTokenAsync(appConfig.username, appConfig.password);
             tok.Wait();
 
-            var ex = run(client, wallabag_poll_duration);
+            // Prep processors
+            var processors = new IProcessor[] {
+                new HNProcessor(),
+                new GenericTagProcessor(processorConfig)
+            };
+
+            var ex = run(client, processors, appConfig.poll_duration);
             ex.Wait();
+            return 0;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Example docker-compose:
 wallabag_reducer:
   image: registry.gitlab.com/georgehahn/wallabag_reducer:latest
   volumes:
-    - ./wallabag_reducer:/database
+    - ./wallabag_reducer:/config
   environment:
     - WALLABAG_URL=http://<wallabag_url>
     - WALLABAG_CLIENT_ID=
@@ -25,5 +25,8 @@ wallabag_reducer:
     - WALLABAG_USERNAME=
     - WALLABAG_PASSWORD=
     - WALLABAG_POLL_DURATION_SECONDS=60
-    - DATABASE_FILE=/database/wallabag_reducer.sqlite3
 ```
+
+# Changelog
+
+See [CHANGELOG.md](CHANGELOG.md)

--- a/WallabagReducer.Net.csproj
+++ b/WallabagReducer.Net.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.1" />
     <PackageReference Include="morelinq" Version="3.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="wallabag.Api" Version="1.5.0" />
   </ItemGroup>
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,11 @@
+{
+    "GenericTagProcessor":
+    {
+        "tag_mapping": [
+            {
+                "domain": "goodreads.com",
+                "tag": "goodreads"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
**Docker breaking change**: replaced `DATABASE_FILE` environment variable with `DATA_DIR` variable. Where `DATABASE_FILE` only set the database path, this variable is used to store the database and the processor configuration file.

Additionally:
- Converted `GoodreadsProcessor` to generic website to tag mapper
- Added processor configuration file (`$DATA_DIR/config.json`)
- Refactored core to enable further extensibility