### PR TITLE
`/config` is a better `DATA_DIR` default

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -121,7 +121,7 @@ namespace WallabagReducer.Net
                 username = Environment.GetEnvironmentVariable("WALLABAG_USERNAME"),
                 password = Environment.GetEnvironmentVariable("WALLABAG_PASSWORD"),
                 poll_duration = int.Parse(Environment.GetEnvironmentVariable("WALLABAG_POLL_DURATION_SECONDS") ?? "60") * 1000,
-                data_dir = Environment.GetEnvironmentVariable("DATA_DIR") ?? "",
+                data_dir = Environment.GetEnvironmentVariable("DATA_DIR") ?? "/config",
                 database_file = "wallabag_reducer.sqlite3",
                 config_file = "config.json"
             };


### PR DESCRIPTION
This makes it unnecessary to set `DATA_DIR` in one's environment. This seems like a reasonable default for this `AppConfig` instance because it has become a de-facto docker config. In the future, a direct-launch config should be built using a better default for that usage scenario.